### PR TITLE
Dockerize

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM socrata/nodejs
+
+ENV APP sr-shelter-sync
+
+WORKDIR /srv
+
+ADD index.js /srv/${APP}/
+ADD package.json /srv/${APP}/
+
+COPY ship.d /etc/ship.d
+
+WORKDIR /srv/${APP}
+
+RUN npm install

--- a/index.js
+++ b/index.js
@@ -10,9 +10,7 @@ var program = require('commander');
 // If modifying these scopes, delete your previously saved credentials
 // at ~/.credentials/sheets.googleapis.com-nodejs-quickstart.json
 var SCOPES = ['https://www.googleapis.com/auth/spreadsheets.readonly'];
-var TOKEN_DIR = (process.env.HOME || process.env.HOMEPATH ||
-    process.env.USERPROFILE) + '/.credentials/';
-var TOKEN_PATH = TOKEN_DIR + 'sheets.googleapis.com-santa-rosa-map.json';
+var TOKEN_PATH = 'sheets.googleapis.com-santa-rosa-map.json';
 
 program
   .version('0.0.1')

--- a/ship.d/run
+++ b/ship.d/run
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+source /dev/shm/sr-shelter-sync.env
+
+cp /dev/shm/sr-client-secret.json ./client_secret.json
+cp /dev/shm/sr-shelter-sync.token.json ./sheets.googleapis.com-santa-rosa-map.json
+
+set -vx
+
+node index.js -p ${PASSWORD} -u ${USERNAME} -t ${API_TOKEN}


### PR DESCRIPTION
Add a Dockerfile (to dockerize) and a run script. The run script assumes that the following files have been uploaded to Clortho (and thus specified as resources to the Chronos job):

sr-shelter-sync.env  # Socrata creds (USERNAME, PASSWORD, API_TOKEN)
client_secret.json
sheets.googleapis.com-santa-rosa-map.json

